### PR TITLE
Add tests for LSSSheet name resolution

### DIFF
--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,21 @@
+import json
+import sys
+from pathlib import Path
+import pytest
+
+# Ensure project root is on sys.path for imports
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from backend.app.models import LSSSheet
+
+
+@pytest.mark.parametrize(
+    "payload, expected_name",
+    [
+        ({"data": json.dumps({"name": {"value": "Rick"}})}, "Rick"),
+        ({"data": {}, "name": "Morty"}, "Morty"),
+        ({"data": {}}, "Безымянный"),
+    ],
+)
+def test_lsssheet_name_resolution(payload, expected_name):
+    sheet = LSSSheet(payload=payload, name=None)
+    assert sheet.name == expected_name


### PR DESCRIPTION
## Summary
- add tests for LSSSheet validator covering JSON string, payload name fallback and default name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c8352885c832ca9e0330cb8007373